### PR TITLE
fix cases where the python-whois module fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Flask_Whois is a web application that allows you to look up domain names and IP 
 - Python 3.x
 - Flask
 - Python `whois` package
+- **`whois` command installed** on the system for domain lookup (see below for Docker support)
 - Docker (for containerized deployment)
 
 ### Installation
@@ -45,6 +46,22 @@ Flask_Whois is a web application that allows you to look up domain names and IP 
    pip install -r requirements.txt
    ```
 
+4. **Ensure `whois` is installed (if you're not using docker)**
+
+   On Linux and macOS, you can install the `whois` command using your package manager.  
+   - **Linux (Debian-based)**:  
+     ```bash
+     sudo apt-get install whois
+     ```
+   - **macOS (with Homebrew)**:  
+     ```bash
+     brew install whois
+     ```
+
+   On **Windows**, you will need to install `whois` manually, such as from [Microsoft Sysinternals](https://learn.microsoft.com/en-us/sysinternals/downloads/whois).
+
+   **Note:** If the `whois` command is not available on your system, you can deploy and run the app using Docker.
+
 ### Usage
 
 1. **Run the application**
@@ -59,7 +76,7 @@ Flask_Whois is a web application that allows you to look up domain names and IP 
 
 ### Docker Support
 
-Flask_Whois can be deployed using Docker for ease of setup and scalability.
+Flask_Whois can be deployed using Docker, which comes pre-configured with the `whois` command to avoid system-specific installations.
 
 1. **Build the Docker image**
 
@@ -93,12 +110,17 @@ services:
 1. **Run the application with Docker Compose**
 
    ```bash
-   docker-compose up -d
+   docker-compose up -d --build
    ```
 
 2. **Access the app**
 
    Open your browser and navigate to `http://127.0.0.1:8000/`.
+
+### Important Notes
+
+- If you are not using Docker, ensure that the `whois` command is installed on your system to perform domain lookups.  
+- For a smoother setup, consider using Docker, which includes the `whois` command in the container.
 
 ### Contributing
 

--- a/app.py
+++ b/app.py
@@ -1,10 +1,11 @@
 from flask import Flask,request,render_template
 from whois import whois
+import subprocess
 
 app = Flask(__name__)
 
 def format_date(date_obj):
-    if date_obj == None or isinstance(date_obj, str):
+    if isinstance(date_obj, str):
         return date_obj
     def get_ordinal(n):
         suffix = "th" if 11 <= n % 100 <= 13 else {1: "st", 2: "nd", 3: "rd"}.get(n % 10, "th")
@@ -16,6 +17,14 @@ def format_date(date_obj):
     else:
         return f"{get_ordinal(date_obj.day)} {date_obj.strftime('%B %Y')}"
 
+def lookup_whois(domain):
+    try:
+        command = ['whois', domain]
+        result = subprocess.run(command, capture_output=True, text=True, timeout=10)
+        return result.stdout
+    except subprocess.TimeoutExpired:
+        return "The whois command timed out"
+
 @app.route("/",methods=["GET"]) #homepage
 def home():
     r = render_template("index.html",title="whois",description="Lookup domains and IP Addresses.")
@@ -24,11 +33,14 @@ def home():
 @app.route("/lookup",methods=["POST"]) # this end point is used by the form in the home page to post domain or IP-address
 def lookup():
     query = request.form["query"]
-    try:
-        result = whois(query)
-    except:
-        return render_template("error.html",error=f"{query} doesn't exist.",title="Invalid Input")
-    return render_template("details.html", exp=format_date(result["expiration_date"]), code=result.text)
+    result = whois(query)
+    text_result = result.text
+    if result["domain_name"] is None:
+        text_result = lookup_whois(query)
+        expiry_date = "Not Available"
+    else:
+        expiry_date = format_date(result["expiration_date"])
+    return render_template("details.html", exp=expiry_date, code=text_result)
 
 if __name__ == "__main__":
     app.run(debug=True,host="0.0.0.0")


### PR DESCRIPTION
In cases where the python-whois module fails to retrieve whois data, we run the system whois command and return the output text to the user.